### PR TITLE
set default-directory to password-store directory

### DIFF
--- a/pass.el
+++ b/pass.el
@@ -81,7 +81,8 @@
 \\{pass-mode-map}"
   (kill-all-local-variables)
   (setq major-mode 'pass-mode
-        mode-name 'Password-Store)
+        mode-name 'Password-Store
+        default-directory (password-store-dir))
   (read-only-mode)
   (use-local-map pass-mode-map)
   (run-hooks 'pass-mode-hook))


### PR DESCRIPTION
Hello,

I found setting the default-directory to my password-store directory/repository quite convenient. Now calling `magit-status` pops up the right thing for me. I thought it might be useful not just for me…?