### PR TITLE
Derive pass-mode from fundamental-mode

### DIFF
--- a/pass.el
+++ b/pass.el
@@ -82,7 +82,7 @@
   "Face for displaying password-store directory names."
   :group 'pass)
 
-(define-derived-mode pass-mode nil "Password-Store"
+(define-derived-mode pass-mode fundamental-mode "Password-Store"
   "Major mode for editing password-stores.
 
 \\{pass-mode-map}"


### PR DESCRIPTION
Thanks for an awesome Emacs interface to pass! 

I use [Spacemacs](https://spacemacs.org), which makes the assumption that all major modes derive from `fundamental-mode`. If a major mode doesn't derive from `fundamental-mode`, certain functionality (specifically Spacemac's keybinding functions) won't work. See [this StackExchange answer](https://emacs.stackexchange.com/a/29066). This PR simply derives `pass-mode` from `fundamental-mode`, which shouldn't break any existing functionality and enables `pass-mode` to play nice with Spacemacs.
  