### PR TITLE
Do not create entries for Emacs backup files

### DIFF
--- a/pass.el
+++ b/pass.el
@@ -434,7 +434,8 @@ If SUBDIR is nil, return the entries of `(password-store-dir)'."
                 (delq nil
                       (mapcar 'pass--tree
                               (f-entries path)))))
-      (when (equal (f-ext path) "gpg")
+      (when (and (equal (f-ext path) "gpg")
+                 (not (backup-file-name-p path)))
         (password-store--file-to-entry path)))))
 
 ;;; major mode for viewing entries


### PR DESCRIPTION
Emacs backup files might contain an out-of-date password, thus
these entries must be ignored.
* pass.el (pass--tree): Ignore Emacs backup files (Fix issue #31).