### PR TITLE
Add feature to jump between entries

### DIFF
--- a/README.md
+++ b/README.md
@@ -30,6 +30,7 @@ The following keybindings are available:
 - `?`: Help
 - `g`: Update the password-store buffer
 - `RET` or `v`: Go to the entry at point
+- `j`: Jump to a given entry
 - `q`: Quit pass
 
 #### 2FA / OTP Support
@@ -77,7 +78,7 @@ Yes, please do! See [CONTRIBUTING][] for guidelines.
 
 ## License
 
-See [LICENSE][]. Copyright (c) 2015-2016 Nicolas Petton & Damien Cassou.
+See [LICENSE][]. Copyright (c) 2015-2019 Nicolas Petton & Damien Cassou.
 
 
 [CONTRIBUTING]: ./CONTRIBUTING.md

--- a/pass.el
+++ b/pass.el
@@ -1,6 +1,6 @@
 ;;; pass.el --- Major mode for password-store.el -*- lexical-binding: t; -*-
 
-;; Copyright (C) 2015-2017  Nicolas Petton & Damien Cassou
+;; Copyright (C) 2015-2019  Nicolas Petton & Damien Cassou
 
 ;; Author: Nicolas Petton <petton.nicolas@gmail.com>
 ;;         Damien Cassou <damien@cassou.me>
@@ -58,6 +58,7 @@
     (define-key map (kbd "g") #'pass-update-buffer)
     (define-key map (kbd "i") #'pass-insert)
     (define-key map (kbd "I") #'pass-insert-generated)
+    (define-key map (kbd "j") #'pass-goto-entry)
     (define-key map (kbd "w") #'pass-copy)
     (define-key map (kbd "v") #'pass-view)
     (define-key map (kbd "r") #'pass-rename)
@@ -158,6 +159,47 @@ Similar to `save-excursion' but only restore the point."
   (interactive)
   (pass--goto-prev #'pass-entry-at-point))
 
+(defun pass--drop-dir-headers (tree)
+  "Drop all directory headers from TREE.
+TREE is a list as returned by `pass--tree' and it is not modified.
+This returns a flat list with just the entries at TREE."
+  (let (entries)
+    (dolist (entry (cdr tree))
+      (if (atom entry)
+          (push entry entries)
+        (setq entries (append (pass--drop-dir-headers entry) entries))))
+    (nreverse entries)))
+
+(defun pass--entries ()
+  "Collect all entries in the pass buffer."
+  (pass--drop-dir-headers (pass--tree nil)))
+
+(defun pass--target-entry-pos (target)
+  "Return position of TARGET entry or nil if it doesn't exist."
+  (save-excursion
+    (goto-char (point-min))
+    (pass--goto-next (lambda () (equal (pass-entry-at-point) target)))
+    (unless (eobp)
+      (point))))
+
+(defun pass-goto-entry (entry)
+  "Move point to ENTRY and return its position.
+If ENTRY doesn't exist in the buffer, then preserve point and return nil.
+
+Note that ENTRY must reflect its deep level in the directory structure;
+for instance, an entry `bar' inside the subdirectory `foo', must be
+specified as `foo/bar'.
+
+When called interactively, prompt users with completion using
+all entries in the pass buffer."
+  (interactive
+   (list (completing-read "Jump to entry: " (pass--entries) nil 'match)))
+  (let ((entry-pos (pass--target-entry-pos entry)))
+    (if entry-pos
+        (goto-char entry-pos)
+      (message "No entry matches %s in current directory" entry)
+      nil)))
+
 (defun pass-next-directory ()
   "Move point to the next directory found."
   (interactive)
@@ -255,7 +297,7 @@ user input."
   (when pass-show-keybindings
     (pass--display-keybindings '((pass-copy . "Copy password")
                                  (pass-view . "View entry")
-                                 (pass-otp-options . "OTP Support")))
+                                 (pass-goto-entry . "Jump to Entry")))
     (insert "\n")
     (pass--display-keybindings '((pass-insert . "Insert")
                                  (pass-next-entry . "Next")
@@ -263,10 +305,11 @@ user input."
     (insert "\n")
     (pass--display-keybindings '((pass-insert-generated . "Generate")
                                  (pass-prev-entry . "Previous")
-                                 (describe-mode . "Help")))
+                                 (pass-otp-options . "OTP Support")))
     (insert "\n")
     (pass--display-keybindings '((pass-rename . "Rename")
-                                 (pass-next-directory . "Next dir")))
+                                 (pass-next-directory . "Next dir")
+                                 (describe-mode . "Help")))
     (insert "\n")
     (pass--display-keybindings '((pass-kill . "Delete")
                                  (pass-prev-directory . "Previous dir")))
@@ -297,7 +340,7 @@ BINDINGS is an alist of bindings."
 
 (defun pass--display-keybinding (command label)
   "Insert the associated keybinding for COMMAND with LABEL."
-  (insert (format "%8s %-12s \t "
+  (insert (format "%8s %-13s \t "
                   (format "%s"
                           (propertize (substitute-command-keys
                                        (format "<\\[%s]>" (symbol-name command)))

--- a/pass.el
+++ b/pass.el
@@ -159,21 +159,6 @@ Similar to `save-excursion' but only restore the point."
   (interactive)
   (pass--goto-prev #'pass-entry-at-point))
 
-(defun pass--drop-dir-headers (tree)
-  "Drop all directory headers from TREE.
-TREE is a list as returned by `pass--tree' and it is not modified.
-This returns a flat list with just the entries at TREE."
-  (let (entries)
-    (dolist (entry (cdr tree))
-      (if (atom entry)
-          (push entry entries)
-        (setq entries (append (pass--drop-dir-headers entry) entries))))
-    (nreverse entries)))
-
-(defun pass--entries ()
-  "Collect all entries in the pass buffer."
-  (pass--drop-dir-headers (pass--tree nil)))
-
 (defun pass--target-entry-pos (target)
   "Return position of TARGET entry or nil if it doesn't exist."
   (save-excursion
@@ -193,7 +178,8 @@ specified as `foo/bar'.
 When called interactively, prompt users with completion using
 all entries in the pass buffer."
   (interactive
-   (list (completing-read "Jump to entry: " (pass--entries) nil 'match)))
+   (list (completing-read "Jump to entry: "
+                          (password-store-list) nil 'match)))
   (let ((entry-pos (pass--target-entry-pos entry)))
     (if entry-pos
         (goto-char entry-pos)

--- a/test/pass-tests.el
+++ b/test/pass-tests.el
@@ -1,6 +1,6 @@
 ;;; pass-tests.el --- Tests for pass.el
 
-;; Copyright (C) 2013 Damien Cassou
+;; Copyright (C) 2013-2019 Damien Cassou
 
 ;; Author: Damien Cassou <damien.cassou@gmail.com>
 
@@ -26,6 +26,33 @@
 ;;; Code:
 
 (require 'ert)
+(require 'pass)
+(require 'password-store)
+
+(ert-deftest pass-goto-entry-tests ()
+  "Tests for `pass-goto-entry`."
+  ;; Test requirements:
+  ;; 1) The pass executable must exist
+  ;; 2) The password storage must be initialized with a valid public key (pass init GPG-ID)
+  (skip-unless (and (executable-find password-store-executable)
+                    (file-exists-p (expand-file-name ".password-store"
+                                                     (getenv "HOME")))))
+  (let ((entries '("pass-goto-entry-test-1" "pass-goto-entry-test-2")))
+    (pass)
+    (unwind-protect
+        (progn
+          (dolist (entry entries)
+            (password-store-generate entry)
+            (pass-update-buffer)
+            ;; Users can jump into an existing entry...
+            (should (pass-goto-entry entry)))
+          ;; ...but they cannot jump into non-existent ones
+          (should-not (pass-goto-entry "pass-goto-entry-test-999")))
+      ;; Delete created entries
+      (dolist (entry entries)
+        (password-store-remove entry))
+      (pass-update-buffer))))
+          
 
 (provide 'pass-tests)
 

--- a/test/pass-tests.el
+++ b/test/pass-tests.el
@@ -1,6 +1,6 @@
 ;;; pass-tests.el --- Tests for pass.el
 
-;; Copyright (C) 2013-2019 Damien Cassou
+;; Copyright (C) 2013 Damien Cassou
 
 ;; Author: Damien Cassou <damien.cassou@gmail.com>
 
@@ -26,33 +26,6 @@
 ;;; Code:
 
 (require 'ert)
-(require 'pass)
-(require 'password-store)
-
-(ert-deftest pass-goto-entry-tests ()
-  "Tests for `pass-goto-entry`."
-  ;; Test requirements:
-  ;; 1) The pass executable must exist
-  ;; 2) The password storage must be initialized with a valid public key (pass init GPG-ID)
-  (skip-unless (and (executable-find password-store-executable)
-                    (file-exists-p (expand-file-name ".password-store"
-                                                     (getenv "HOME")))))
-  (let ((entries '("pass-goto-entry-test-1" "pass-goto-entry-test-2")))
-    (pass)
-    (unwind-protect
-        (progn
-          (dolist (entry entries)
-            (password-store-generate entry)
-            (pass-update-buffer)
-            ;; Users can jump into an existing entry...
-            (should (pass-goto-entry entry)))
-          ;; ...but they cannot jump into non-existent ones
-          (should-not (pass-goto-entry "pass-goto-entry-test-999")))
-      ;; Delete created entries
-      (dolist (entry entries)
-        (password-store-remove entry))
-      (pass-update-buffer))))
-          
 
 (provide 'pass-tests)
 


### PR DESCRIPTION
Add a command `pass-goto-entry' for moving to any
entry in the pass buffer (Issue #34).
Update copyright notices.
* pass.el (pass--drop-dir-headers, pass--entries)
(pass--target-entry-pos): New internal functions.
(pass-goto-entry): New command; bind it to 'j'.
(pass-show-keybindings): Show it in the header.
(pass--display-keybinding): Update formatting to give enough space
for the new command description.

* test/pass-tests.el (pass-goto-entry-tests): Add test.

* README.md: Document the new keybinding.