### PR TITLE
Use right store dir to ensure `pass-view-mode` activate properly

### DIFF
--- a/pass.el
+++ b/pass.el
@@ -620,7 +620,11 @@ This function also binds a couple of handy OTP related key-bindings to
    (substitute-command-keys
     "Press <\\[pass-view-toggle-password]> to display & edit the password")))
 
-(add-to-list 'auto-mode-alist '("\\.password-store/.*\\.gpg\\'" . pass-view-mode))
+(add-to-list 'auto-mode-alist
+             (cons
+              (format "%s/.*\\.gpg\\'"
+                      (expand-file-name (password-store-dir)))
+              'pass-view-mode))
 
 (provide 'pass)
 ;;; pass.el ends here


### PR DESCRIPTION
If the password directory is customised (to something else than `~/.password-store`), `pass-view-mode` doesn't activate properly.

This PR fixes that by replacing the hard-written `~/.password-store` by a call to `(password-store-dir)`.