### PR TITLE
Support extraction of fields other than password

### DIFF
--- a/README.md
+++ b/README.md
@@ -25,8 +25,13 @@ The following keybindings are available:
 - `M-n`: Go to the next directory
 - `M-p`: Go to the previous directory
 - `k`: Remove the entry at point
+- `w`: Copy password of the entry at point to the kill ring
+- `b`: Copy username of the entry at point to the kill ring
+- `u`: Copy url of the entry at point to the kill ring
+- `f`: Copy a given secret field of the entry at point to the kill ring
+- `U`: Browse to the url of the entry at point with the default web browser
 - `s`: Trigger iSearch
-- `r`: Trigger iSearch (backward)
+- `r`: Rename the entry at point
 - `?`: Help
 - `g`: Update the password-store buffer
 - `RET` or `v`: Go to the entry at point


### PR DESCRIPTION
Allow users to retrieve any secret field stored in the file.
The new command, `pass-copy-field' receives the wanted field as input,
and returns its secret value for the entry at point.

For convenience, the two new commands `pass-copy-username' and
`pass-copy-url' handle the common case for an user login (Issue #29).

The new command `pass-browse-url' directs the default browser to the
stored url at the entry at point.

Replace Emacs dependency from v24.3 to v25, as password-store.el.
Bump version to v1.9.

* pass.el (pass--copy-field): Use `password-store-parse-entry'.
(pass-username-field): New option
(pass-copy-username): New command.  Bind it to 'b'.
(pass-copy-url): New command.  Bind it to 'u'.
(pass-browse-url): New command.  Bind it to 'U'.
(pass-copy-field): New command.  Bind it to 'f'.

* README.md: Document the new keybindings.