### PR TITLE
Improve Font Lock: allow white space and avoid multiple colon

### DIFF
--- a/pass.el
+++ b/pass.el
@@ -656,7 +656,7 @@ This function also binds a couple of handy OTP related key-bindings to
   (pass--with-closest-entry entry
     (password-store-url entry)))
 
-(defvar pass-view-font-lock-keywords '("^[^\s\n]+:" . 'font-lock-keyword-face)
+(defvar pass-view-font-lock-keywords '("\\(^[^:\t\n]+:\\) " 1 'font-lock-keyword-face)
   "Font lock keywords for ‘pass-view-mode’.")
 
 (define-derived-mode pass-view-mode nil "Pass-View"


### PR DESCRIPTION
There is no problem for `pass` for handling a field with a white space on it.  This modification ensures the Font Lock of `pass-view-mode` indicates that.  As extra modifications, we avoid highlighting after the first colon.  And for correct highlighting, the colon that separates the field from its value must be followed by white space. It also avoids highlighting part of passphrases that contain colon on it.