### PR TITLE
feat: add an option to fallback on the entry's name for username

### DIFF
--- a/README.md
+++ b/README.md
@@ -41,6 +41,24 @@ The following keybindings are available:
 - `j`: Jump to a given entry
 - `q`: Quit pass
 
+#### Configuration
+
+##### `pass-username-fallback-on-filename`
+
+Some applications/extensions rely on a password store structure that
+exposes the username as the entry name, i.e:
+
+```
+example.com/
+  john@doe.com
+```
+
+If `pass-username-fallback-on-filename` is non-nil, the copy username
+command will still try to find a `password` field within the entry but
+fallback to the entry name if the field isn't found. In the example
+above, `john@doe.com` will be used in place (unless the entry does
+contain a `password` field).
+
 #### 2FA / OTP Support
 
 If you have the [`pass-otp`](https://github.com/tadfisher/pass-otp) extension


### PR DESCRIPTION
Hello! Thanks for `pass.el`. 

I use my password store keyed by username (rather than an actual `username` field in the entry), and have had some custom code to redirect `pass-copy-username` for some time. I thought I'd tidy it up and try and get it merged upstream, but no worries if it isn't of interest here.

commit message:

```
One of the way to organise the password store is having passwords
keyed by username, as advocated by this chrome-pass extension[1].

Add an option - `pass-username-fallback-on-filename` - to accomodate
this layout. When asked to copy the username field:

1. try the actual username field;
2. if no username field is present:
 2.1 and the option isn't set, rethrow the error as normal;
 2.2 and the option is set, gets the entry filename instead and copies
 this in the kill ring through the same temporary mecanism that pass
 does.

[1]: https://github.com/hsanson/chrome-pass/#password-paths
```