### PR TITLE
Derive pass-mode from special-mode to fix issue with view-read-only

### DIFF
--- a/pass.el
+++ b/pass.el
@@ -92,7 +92,7 @@
   "Face for displaying password-store directory names."
   :group 'pass)
 
-(define-derived-mode pass-mode fundamental-mode "Password-Store"
+(define-derived-mode pass-mode special-mode "Password-Store"
   "Major mode for editing password-stores.
 
 \\{pass-mode-map}"


### PR DESCRIPTION
`pass-mode` should derive from `special-mode`, not `fundamental-mode`.
See the excerpt below from the GNU Emacs manual explaining
`special-mode`:

> Special mode is a basic major mode for buffers containing text that
> is produced specially by Emacs, rather than directly from a file.

Deriving from `special-mode` fixes the issue of the `pass-mode`
keybindings being shadowed by `view-mode` keybindings for users with
`view-read-only` set to `t`. This is because `view-read-only` ignores
read-only buffers with a `mode-class` of `special`.