### PR TITLE
Define face for key bindings

### DIFF
--- a/pass.el
+++ b/pass.el
@@ -634,7 +634,7 @@ This function only works when `pass-view-mode' is enabled."
                           token " - " remaining-secs "s remaining"))
         (key-binding (concat (propertize (substitute-command-keys
                                           (format "<\\[%s]>" "pass-view-copy-token"))
-                                         'face 'font-lock-constant-face)
+                                         'face 'pass-mode-keybinding-face)
                              " Copy token")))
     (setq header-line-format (concat otp-data "    " key-binding))
     (force-mode-line-update)))

--- a/pass.el
+++ b/pass.el
@@ -87,6 +87,10 @@
   "Face for displaying the header of the pass buffer."
   :group 'pass)
 
+(defface pass-mode-keybinding-face '((t :inherit font-lock-constant-face))
+  "Face for displaying pass key bindings."
+  :group 'pass)
+
 (defface pass-mode-entry-face '((t . ()))
   "Face for displaying pass entry names."
   :group 'pass)
@@ -400,7 +404,7 @@ BINDINGS is an alist of bindings."
                   (format "%s"
                           (propertize (substitute-command-keys
                                        (format "<\\[%s]>" (symbol-name command)))
-                                      'face 'font-lock-constant-face))
+                                      'face 'pass-mode-keybinding-face))
                   label)))
 
 (defun pass-display-item (item &optional indent-level)


### PR DESCRIPTION
It inherits from font-lock-constant-face to remain backward-compatible with the previous style.

Closes #51.