### PR TITLE
Correct password-store version

### DIFF
--- a/pass.el
+++ b/pass.el
@@ -4,9 +4,9 @@
 
 ;; Author: Nicolas Petton <petton.nicolas@gmail.com>
 ;;         Damien Cassou <damien@cassou.me>
-;; Version: 2.0
-;; GIT: https://github.com/NicolasPetton/pass
-;; Package-Requires: ((emacs "25") (password-store "2.1.0") (password-store-otp "0.1.5") (f "0.17"))
+;; Version: 2.0.1
+;; URL: https://github.com/NicolasPetton/pass
+;; Package-Requires: ((emacs "25") (password-store "1.7.4") (password-store-otp "0.1.5") (f "0.17"))
 ;; Created: 09 Jun 2015
 ;; Keywords: password-store, password, keychain
 


### PR DESCRIPTION
The version number here is the tagged version for a password-store release and not that of password-store.el.  Though they are maintained in the same repository [1].

1.7.4 is the latest stable release of password-store (or pass) released on 2021-06-11 and included v2.1.4 of password-store.el.

Fixes: #48

[1] https://git.zx2c4.com/password-store/