### PR TITLE
Correct the version of password-store-otp

### DIFF
--- a/pass.el
+++ b/pass.el
@@ -6,7 +6,7 @@
 ;;         Damien Cassou <damien@cassou.me>
 ;; Version: 2.0.1
 ;; URL: https://github.com/NicolasPetton/pass
-;; Package-Requires: ((emacs "25") (password-store "1.7.4") (password-store-otp "0.1.5") (f "0.17"))
+;; Package-Requires: ((emacs "25") (password-store "1.7.4") (password-store-otp "0.1.0") (f "0.17"))
 ;; Created: 09 Jun 2015
 ;; Keywords: password-store, password, keychain
 


### PR DESCRIPTION
It seems that version 0.1.5 does not exist anywhere.

So just follow origin version:
https://github.com/volrath/password-store-otp.el/blob/be3a00a981921ed1b2f78012944dc25eb5a0beca/password-store-otp.el#L6