### PR TITLE
Reduce scope of inhibit-message

### DIFF
--- a/pass.el
+++ b/pass.el
@@ -306,8 +306,9 @@ user input."
 (defun pass--copy-field (field)
   "Add FIELD of entry at point to kill ring."
   (pass--with-closest-entry entry
-    (let* ((inhibit-message t)
-           (parsed-entries (password-store-parse-entry entry)))
+    (let ((parsed-entries
+           (let ((inhibit-message t))
+             (password-store-parse-entry entry))))
       (unless (assoc field parsed-entries)
         (user-error "Field `%s' not in  %s" field entry))
       (password-store-copy-field entry field))))


### PR DESCRIPTION
* pass.el (pass--copy-field): Limit `inhibit-message` to the call to `password-store-parse-entry`. Let `password-store-copy-field` decide whether to suppress messages or not.