### PR TITLE
Trim whitespace when displaying OTP token

### DIFF
--- a/pass.el
+++ b/pass.el
@@ -680,7 +680,8 @@ This function only works when `pass-view-mode' is enabled."
   "Display OTP TOKEN and REMAINING-SECS in Header Line."
   (let ((otp-data (concat (propertize " " 'display '((space :align-to 0)))
                           (propertize "OTP: " 'face 'pass-mode-header-face)
-                          token " - " remaining-secs "s remaining"))
+                          (string-trim token)
+                          " - " remaining-secs "s remaining"))
         (key-binding (concat (propertize (substitute-command-keys
                                           (format "<\\[%s]>" "pass-view-copy-token"))
                                          'face 'pass-mode-keybinding-face)


### PR DESCRIPTION
password-store-otp-token returns a token with a final newline. This shows up in the OTP header line like this:
```
OTP: 123456^J - 15s remaining    <C-c C-o> Copy token
```
Prevent this by trimming the token string in pass-view--set-otp-header.